### PR TITLE
유저세팅 api, 토큰 로직 정상작동, 토큰 기간 수정, 현재 졉속 유저 pk 찾아오기

### DIFF
--- a/server/timer-service/build.gradle
+++ b/server/timer-service/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-
+    implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.4.2'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/TimerServiceApplication.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/TimerServiceApplication.java
@@ -39,15 +39,6 @@ public class TimerServiceApplication {
     }
 
 
-    @Component
-    @RequiredArgsConstructor
-    static class MyApplicationRunner implements ApplicationRunner {
-        private final OAuthProperties oAuthProperties;
 
-        @Override
-        public void run(ApplicationArguments args) throws Exception {
-            OAuthVendor.oAuthProperties = oAuthProperties;
-        }
-    }
 
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/TimerServiceApplication.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/TimerServiceApplication.java
@@ -1,34 +1,53 @@
 package com.gdsc.timerservice;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdsc.timerservice.config.properties.AppProperties;
 import com.gdsc.timerservice.config.properties.OAuthProperties;
 import com.gdsc.timerservice.oauth.model.OAuthVendor;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableConfigurationProperties(value = {AppProperties.class, OAuthProperties.class})
 public class TimerServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(TimerServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(TimerServiceApplication.class, args);
+    }
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 
 
-	@Component
-	@RequiredArgsConstructor
-	static class MyApplicationRunner implements ApplicationRunner {
-		private final OAuthProperties oAuthProperties;
+    @Component
+    @RequiredArgsConstructor
+    static class MyApplicationRunner implements ApplicationRunner {
+        private final OAuthProperties oAuthProperties;
 
-		@Override
-		public void run(ApplicationArguments args) throws Exception {
-			OAuthVendor.oAuthProperties = oAuthProperties;
-		}
-	}
+        @Override
+        public void run(ApplicationArguments args) throws Exception {
+            OAuthVendor.oAuthProperties = oAuthProperties;
+        }
+    }
 
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
@@ -1,12 +1,12 @@
 package com.gdsc.timerservice.api.controller.user;
 
 import com.gdsc.timerservice.api.dtos.user.UserSettingRequest;
+import com.gdsc.timerservice.api.entity.user.User;
+import com.gdsc.timerservice.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,17 +17,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
-    private final ModelMapper modelMapper = new ModelMapper();
+    private final ModelMapper modelMapper;
 
     @GetMapping("/") // 메인 페이지. 소셜 로그인할 수 있는 링크들 있음.
-    public String hello() {
+    public String hello(@CurrentUser User user) {
         return "index";
     }
 
     @PatchMapping("/setting")
-    public ResponseEntity setUserSetting(UserSettingRequest request, @AuthenticationPrincipal User user) {
-        //Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        System.out.println(user);
+    public ResponseEntity<String> setUserSetting(UserSettingRequest request,
+                                         @CurrentUser User user) {
+        System.out.println(user.getUserId());
         return ResponseEntity.ok().body("OK");
     }
 

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
@@ -1,23 +1,34 @@
 package com.gdsc.timerservice.api.controller.user;
 
-import com.gdsc.timerservice.oauth.entity.UserPrincipal;
+import com.gdsc.timerservice.api.dtos.user.UserSettingRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
 
 @Controller
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
 @Slf4j
 public class UserController {
+    private final ModelMapper modelMapper = new ModelMapper();
+
     @GetMapping("/") // 메인 페이지. 소셜 로그인할 수 있는 링크들 있음.
     public String hello() {
         return "index";
+    }
+
+    @PatchMapping("/setting")
+    public ResponseEntity setUserSetting(UserSettingRequest request, @AuthenticationPrincipal User user) {
+        //Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        System.out.println(user);
+        return ResponseEntity.ok().body("OK");
     }
 
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/controller/user/UserController.java
@@ -1,34 +1,67 @@
 package com.gdsc.timerservice.api.controller.user;
 
+import com.gdsc.timerservice.api.dtos.user.GetUserResponse;
 import com.gdsc.timerservice.api.dtos.user.UserSettingRequest;
+import com.gdsc.timerservice.api.dtos.user.UserSettingResponse;
 import com.gdsc.timerservice.api.entity.user.User;
+import com.gdsc.timerservice.api.service.auth.UserService;
 import com.gdsc.timerservice.common.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+@RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
     private final ModelMapper modelMapper;
+    private final UserService userService;
 
     @GetMapping("/") // 메인 페이지. 소셜 로그인할 수 있는 링크들 있음.
     public String hello(@CurrentUser User user) {
         return "index";
     }
 
+    /**
+     * 모든 유저 조회
+     *
+     * @param pageable
+     * @return
+     */
+    @GetMapping("/users")
+    public ResponseEntity<Page<GetUserResponse>> getUsers(Pageable pageable) {
+        return ResponseEntity.ok(userService.queryAllUser(pageable).map(GetUserResponse::new));
+    }
+
+
+    /**
+     * 해당 유저 설정 조회
+     *
+     * @param user
+     * @return
+     */
+    @GetMapping("/setting")
+    public ResponseEntity<UserSettingResponse> getSetting(@CurrentUser User user) {
+        UserSettingResponse response = userService.querySetting(user);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 해당 유저 설정 수정
+     *
+     * @param request
+     * @param user
+     * @return
+     */
     @PatchMapping("/setting")
-    public ResponseEntity<String> setUserSetting(UserSettingRequest request,
-                                         @CurrentUser User user) {
-        System.out.println(user.getUserId());
-        return ResponseEntity.ok().body("OK");
+    public ResponseEntity<String> updateSetting(@RequestBody UserSettingRequest request, @CurrentUser User user) {
+        userService.update(request, user);
+        return ResponseEntity.ok("OK");
     }
 
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/GetUserResponse.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/GetUserResponse.java
@@ -1,0 +1,17 @@
+package com.gdsc.timerservice.api.dtos.user;
+
+import com.gdsc.timerservice.api.entity.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class GetUserResponse {
+    private String username;
+    private String email;
+
+    public GetUserResponse(User user) {
+        this.username = user.getUsername();
+        this.email = user.getEmail();
+    }
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/UserSettingRequest.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/UserSettingRequest.java
@@ -1,0 +1,12 @@
+package com.gdsc.timerservice.api.dtos.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSettingRequest {
+    private Integer timerDuration;
+    private Integer restDuration;
+    private boolean restAutoStart;
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/UserSettingResponse.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/dtos/user/UserSettingResponse.java
@@ -1,0 +1,12 @@
+package com.gdsc.timerservice.api.dtos.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSettingResponse {
+    private Integer timerDuration;
+    private Integer restDuration;
+    private boolean restAutoStart;
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/User.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/User.java
@@ -18,55 +18,40 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "USER")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "USER_ID")
     private Long userId;
 
     @NotNull
     @Size(max = 512)
-    @Column(name = "EMAIL", unique = true) // 이메일은 유일
     private String email;
 
     @JsonIgnore
     @NotNull
     @Size(max = 128)
-    @Column(name = "PASSWORD")
     private String password;
 
-//    @NotNull
-    @Size(max = 100)
-    @Column(name = "USERNAME")
-    private String username;
 
-//    @NotNull
-//    @Column(name = "PROFILE_IMAGE_URL")
-//    @Size(max = 512)
-//    private String profileImageUrl;
+    @Size(max = 100)
+    private String username;
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(name = "PROVIDER_TYPE", length = 20)
     private ProviderType providerType;
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(name = "ROLE_TYPE", length = 20)
     private RoleType roleType;
 
     @NotNull
-    @Column(name = "UPDATED_AT")
     @CreatedDate
     private LocalDateTime updatedAt;
 
     @NotNull
     @LastModifiedDate
-    @Column(name = "CREATED_AT")
     private LocalDateTime createdAt;
 
-    @Column(name = "IMAGE_URL")
     private String imageUrl;
 
     @Builder

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/User.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/User.java
@@ -55,7 +55,7 @@ public class User {
     private String imageUrl;
 
     @Builder
-    public User(String email, String password, String username, ProviderType providerType, RoleType roleType){
+    public User(String email, String password, String username, ProviderType providerType, RoleType roleType) {
         this.email = email;
         this.password = password;
         this.username = username;
@@ -65,5 +65,11 @@ public class User {
 
     public User(Long userId) {
         this.userId = userId;
+    }
+
+    public User(User user) {
+        this.username = user.getUsername();
+        this.roleType = user.getRoleType();
+        this.email = user.getEmail();
     }
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserRefreshToken.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserRefreshToken.java
@@ -6,25 +6,21 @@ import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 
 @Entity
-@Table(name = "USER_REFRESH_TOKEN")
 @Builder @Setter @Getter
 @NoArgsConstructor @AllArgsConstructor
 public class UserRefreshToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "ID")
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "USER_ID")
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @Column(name = "EMAIL", unique = true)
     @NotNull
     private String email;
 
-    @Column(name = "REFRESH_TOKEN")
     @NotNull
     private String refreshToken;
 

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserSetting.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserSetting.java
@@ -1,0 +1,28 @@
+package com.gdsc.timerservice.api.entity.user;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Integer timerDuration; // 메인 화면에 표시될 타이머 진행시킬 시간
+
+    private Integer restDuration;
+
+    private boolean restAutoStart; // 휴식 시간 종료 후 타이머 자동 시작 여부
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserSetting.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/entity/user/UserSetting.java
@@ -20,9 +20,9 @@ public class UserSetting {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private Integer timerDuration; // 메인 화면에 표시될 타이머 진행시킬 시간
+    private Integer timerDuration = 50; // 메인 화면에 표시될 타이머 진행시킬 시간
 
-    private Integer restDuration;
+    private Integer restDuration = 5;
 
-    private boolean restAutoStart; // 휴식 시간 종료 후 타이머 자동 시작 여부
+    private boolean restAutoStart = false; // 휴식 시간 종료 후 타이머 자동 시작 여부
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/repository/user/UserRepository.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/repository/user/UserRepository.java
@@ -4,9 +4,11 @@ import com.gdsc.timerservice.api.entity.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     // 데이터베이스에 이미 있는 이메일인지 체크하기 위한 메서드(즉, 이전에 가입한 사람인지 체크)
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/repository/user/UserSettingRepository.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/repository/user/UserSettingRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.timerservice.api.repository.user;
+
+import com.gdsc.timerservice.api.entity.user.UserSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/OAuth2Service.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/OAuth2Service.java
@@ -3,8 +3,10 @@ package com.gdsc.timerservice.api.service.auth;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdsc.timerservice.api.entity.user.User;
+import com.gdsc.timerservice.api.entity.user.UserSetting;
 import com.gdsc.timerservice.api.repository.user.UserRefreshTokenRepository;
 import com.gdsc.timerservice.api.repository.user.UserRepository;
+import com.gdsc.timerservice.api.repository.user.UserSettingRepository;
 import com.gdsc.timerservice.config.properties.AppProperties;
 import com.gdsc.timerservice.oauth.entity.ProviderType;
 import com.gdsc.timerservice.oauth.entity.RoleType;
@@ -38,6 +40,7 @@ public class OAuth2Service {
 
 
     private final UserRepository userRepository;
+    private final UserSettingRepository userSettingRepository;
     private final AuthTokenProvider tokenProvider;
     private final AppProperties appProperties;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
@@ -78,7 +81,18 @@ public class OAuth2Service {
                 .roleType(RoleType.USER)
                 .build();
 
-        return userRepository.save(user);
+        User savedUser = userRepository.saveAndFlush(user);
+        // default 유저 세팅 저장
+        UserSetting userSetting = UserSetting.builder()
+                .user(user)
+                .timerDuration(25)
+                .restDuration(5)
+                .restAutoStart(false)
+                .build();
+
+        userSettingRepository.saveAndFlush(userSetting);
+
+        return savedUser;
     }
 
     private User updateOAuthInfo(String email, User user) {

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/OAuth2Service.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/OAuth2Service.java
@@ -19,24 +19,24 @@ import com.gdsc.timerservice.oauth.token.AuthToken;
 import com.gdsc.timerservice.oauth.token.AuthTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OAuth2Service {
 
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
 
 
     private final UserRepository userRepository;
@@ -45,63 +45,9 @@ public class OAuth2Service {
     private final AppProperties appProperties;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
 
-    /**
-     * 소셜로그인 사용자들을 강제 회원가입한다.<br/>
-     * 이전에 가입된 회원이라면(이메일로 회원 조회시 값 존재) updateUser 로 소셜의 사용자 정보를 업데이트하여 저장한다.<br/>
-     * 만약 이전에 가입된 회원이지만(이메일로 회원 조회시 값 존재), 이전에 가입했던 소셜 벤더가 아니라면 OAuthProviderMissMatchException 익셉션을 던진다.<br/>
-     */
-    public User socialJoin(String code, String vendor) throws JsonProcessingException {
-        AbstractProfile profile = getProfile(code, vendor);
-        User existingUser = userRepository.findByEmail(profile.getEmail()); // 이미 가입된 유저(이메일)인지 체크하기 위함.
 
-        if (existingUser != null) { // 이미 가입된 유저(이메일)라면
-            if (profile.getProviderType() != existingUser.getProviderType()) { // 이미 가입된 유저(이메일)인데 다른 소셜벤더로 로그인한 경우
-                throw new OAuthProviderMissMatchException(
-                        "이전에 " + profile.getEmail() + " 계정으로 로그인하셨던 적이 있습니다."
-                );
-            }
-
-            // TODO 유저 정보 업데이트시 현재 로그인한 사용자의 이메일만 주면 안되고, 소셜로그인 후 카카오정보서버로부터 받은 모든 정보(이미지Url, 이미지, 닉네임 등)를 담은 객체를 주어야 한다.
-            existingUser = updateOAuthInfo(profile.getEmail(), existingUser);
-        } else { // 처음 로그인하는 회원인경우, 강제 회원가입 진행
-            existingUser = createOAuthUser(profile.getEmail(), profile.getUsername(), profile.getProviderType());
-        }
-
-        return existingUser;
-    }
-
-    private User createOAuthUser(String email, String username, ProviderType providerType) {
-        User user = User.builder()
-                .email(email)
-                .password(UUID.randomUUID().toString()) // 비밀번호는 일단 그냥 UUID 로 하겠음.
-                .username(username)
-                .providerType(providerType)
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .roleType(RoleType.USER)
-                .build();
-
-        User savedUser = userRepository.saveAndFlush(user);
-        // default 유저 세팅 저장
-        UserSetting userSetting = UserSetting.builder()
-                .user(user)
-                .timerDuration(25)
-                .restDuration(5)
-                .restAutoStart(false)
-                .build();
-
-        userSettingRepository.saveAndFlush(userSetting);
-
-        return savedUser;
-    }
-
-    private User updateOAuthInfo(String email, User user) {
-        // TODO oauth 사용자 정보(특히 프로필 url, 닉네임 등이 업데이트 된 경우 우리 서비스에서도 업데이트해줌
-        return user;
-    }
-
-    // 토큰 생성
-    public void generateToken(HttpServletResponse response, Long id, String email, RoleType kakao) throws IOException {
+    @Transactional
+    public TokenResponse generateToken(Long id, String email, RoleType kakao) throws IOException {
         // access token 생성
         Date now = new Date();
         Date accessExpiry = new Date(now.getTime() + appProperties.getAuth().getTokenExpiry());
@@ -118,14 +64,69 @@ public class OAuth2Service {
                 }, () -> {
                     userRefreshTokenRepository.saveNewRefreshToken(id, email, refreshToken.getToken());
                 });
-        response.setStatus(HttpServletResponse.SC_OK); // 200
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        TokenResponse tokenResponse = new TokenResponse(accessToken.getToken(), refreshToken.getToken());
-        response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
+
+        return new TokenResponse(accessToken.getToken(), refreshToken.getToken());
     }
 
-    public AbstractProfile getProfile(String code, String vendor) throws JsonProcessingException {
+    /**
+     * 소셜로그인 사용자들을 강제 회원가입한다.<br/>
+     * 이전에 가입된 회원이라면(이메일로 회원 조회시 값 존재) updateUser 로 소셜의 사용자 정보를 업데이트하여 저장한다.<br/>
+     * 만약 이전에 가입된 회원이지만(이메일로 회원 조회시 값 존재), 이전에 가입했던 소셜 벤더가 아니라면 OAuthProviderMissMatchException 익셉션을 던진다.<br/>
+     */
+    @Transactional
+    public User socialJoin(String code, String vendor) throws JsonProcessingException {
+        var profile = getProfile(code, vendor);
+        return findUser(profile);
+    }
+
+    /**
+     * 중복 가입을 막기 위한 검증을 한다.
+     * 현재 소셜 벤더와 로그인을 시도하는 유저의 이메일로 User 테이블의 벤더사를 비교하여 일치 여부를 반환한다.
+     *
+     *
+     * @param profile 현재 소셜 로그인을 시도하는 유저의 프로필 정보
+     * @param existingUser 현재 소셜 로그인을 시도하는 유저의 이메일로 User 테이블 조회시 반환된 유저
+     * @return 최초 로그인했던 소셜 벤더와 현재 로그인하려는 소셜 벤더의 일치 여부
+     */
+    private boolean isAlreadyJoined(AbstractProfile profile, User existingUser) {
+        return profile.getProviderType() != existingUser.getProviderType();
+    }
+
+    private User findUser(AbstractProfile profile) {
+        Optional<User> optionalUser = userRepository.findByEmail(profile.getEmail());
+        optionalUser.ifPresent(existingUser -> {
+            if (isAlreadyJoined(profile, existingUser)) {
+                throw new OAuthProviderMissMatchException("이전에 " + existingUser.getEmail() + " 계정으로 로그인하셨던 적이 있습니다.");
+            }
+        });
+        return optionalUser.orElseGet(() -> createOAuthUser(profile.getEmail(), profile.getUsername(), profile.getProviderType()));
+    }
+    private User createOAuthUser(String email, String username, ProviderType providerType) {
+        User user = User.builder()
+                .email(email)
+                .password(UUID.randomUUID().toString()) // 비밀번호는 일단 그냥 UUID 로 하겠음.
+                .username(username)
+                .providerType(providerType)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .roleType(RoleType.USER)
+                .build();
+
+        User savedUser = userRepository.saveAndFlush(user);
+        // 유저 세팅 default 저장
+        UserSetting userSetting = UserSetting.builder()
+                .user(user)
+                .timerDuration(25)
+                .restDuration(5)
+                .restAutoStart(false)
+                .build();
+
+        userSettingRepository.saveAndFlush(userSetting);
+
+        return savedUser;
+    }
+
+    private AbstractProfile getProfile(String code, String vendor) throws JsonProcessingException {
         OAuthVendor vendorEnum = OAuthVendor.getVendor(vendor);
         String accessToken = getToken(code, vendorEnum);
         // 2. 액세스 토큰을 요청헤더에 담아 카카오 리소스 서버에 사용자 정보(이메일, 프로필) 요청

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/UserService.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/api/service/auth/UserService.java
@@ -1,0 +1,43 @@
+package com.gdsc.timerservice.api.service.auth;
+
+import com.gdsc.timerservice.api.dtos.user.UserSettingRequest;
+import com.gdsc.timerservice.api.dtos.user.UserSettingResponse;
+import com.gdsc.timerservice.api.entity.user.User;
+import com.gdsc.timerservice.api.entity.user.UserSetting;
+import com.gdsc.timerservice.api.repository.user.UserRepository;
+import com.gdsc.timerservice.api.repository.user.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserSettingRepository userSettingRepository;
+    private final UserRepository userRepository;
+    private final ModelMapper modelMapper;
+
+    public void update(UserSettingRequest request, User user) {
+        Optional<UserSetting> userSetting = userSettingRepository.findById(user.getUserId());
+        userSetting.orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 없습니다." + user.getUserId()));
+        UserSetting setting = userSetting.get();
+        modelMapper.map(request, setting);
+        userSettingRepository.save(setting);
+    }
+
+    public UserSettingResponse querySetting(User user) {
+        Optional<UserSetting> setting = userSettingRepository.findById(user.getUserId());
+        UserSetting userSetting = setting.orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 없습니다." + user.getUserId()));
+
+        return modelMapper.map(userSetting, UserSettingResponse.class);
+    }
+
+
+    public Page<User> queryAllUser(Pageable pageable) {
+        return userRepository.findAll(pageable);
+    }
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/common/annotation/CurrentUser.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/common/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.gdsc.timerservice.common.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CurrentUser {
+}

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/config/properties/OAuthProperties.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/config/properties/OAuthProperties.java
@@ -1,11 +1,15 @@
 package com.gdsc.timerservice.config.properties;
 
+import com.gdsc.timerservice.oauth.model.OAuthVendor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
 
 @Getter
 @Setter
@@ -15,4 +19,15 @@ import org.springframework.context.annotation.PropertySource;
 public class OAuthProperties {
     private String kakaoClientId;
     private String kakaoClientSecret;
+
+    @Component
+    @RequiredArgsConstructor
+    static class OAuthPropertiesRunner implements ApplicationRunner {
+        private final OAuthProperties oAuthProperties;
+
+        @Override
+        public void run(ApplicationArguments args) throws Exception {
+            OAuthVendor.oAuthProperties = oAuthProperties;
+        }
+    }
 }

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/config/security/SecurityConfig.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/config/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable(); // 일단은 csrf 필터 생성을 막음. 즉 스프링 시큐리티에서 기본적으로 제공하는 csrf 필터를 거치지 않음. 어느 인스턴스에서든 이 서버로 접근 가능하지만, csrf 공격에 취약. 그냥 jwt 토큰으로만 접근관리 하겠음.
+        http.csrf().disable();
 
         // 메인화면 ("/" 루트 경로) 는 누구나 접근 가능. 이 경로에서 소셜 로그인 진행.
         http.authorizeRequests()

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/entity/UserPrincipal.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/entity/UserPrincipal.java
@@ -2,26 +2,38 @@ package com.gdsc.timerservice.oauth.entity;
 
 import com.gdsc.timerservice.api.entity.user.User;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import java.util.Collection;
+
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
-public class UserPrincipal implements OAuth2User, UserDetails {
+public class UserPrincipal extends org.springframework.security.core.userdetails.User implements OAuth2User {
 
     private User user;
     private Map<String, Object> oauthUserAttributes;
 
-    public UserPrincipal(User user, Map<String, Object> oauthUserAttributes){
+    public UserPrincipal(User user, Map<String, Object> oauthUserAttributes) {
+        super(user.getUsername(), user.getPassword(), convertToAuthorities(user));
         this.user = user;
         this.oauthUserAttributes = oauthUserAttributes;
     }
+
+    private static Set<SimpleGrantedAuthority> convertToAuthorities(User user) {
+        return Stream.of(user.getRoleType().getCode())
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toSet());
+    }
+
+//    public UserPrincipal(User user, Map<String, Object> oauthUserAttributes) {
+//        this.user = user;
+//        this.oauthUserAttributes = oauthUserAttributes;
+//    }
 
 
     @Override
@@ -49,10 +61,6 @@ public class UserPrincipal implements OAuth2User, UserDetails {
         return null;
     }
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
-    }
 
     @Override
     public String getPassword() {

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/entity/UserPrincipal.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/entity/UserPrincipal.java
@@ -30,11 +30,6 @@ public class UserPrincipal extends org.springframework.security.core.userdetails
                 .collect(Collectors.toSet());
     }
 
-//    public UserPrincipal(User user, Map<String, Object> oauthUserAttributes) {
-//        this.user = user;
-//        this.oauthUserAttributes = oauthUserAttributes;
-//    }
-
 
     @Override
     public boolean isAccountNonExpired() {

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -12,6 +12,7 @@ import com.gdsc.timerservice.oauth.token.AuthToken;
 import com.gdsc.timerservice.oauth.token.AuthTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -32,7 +33,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
     private final AuthTokenProvider tokenProvider;
     private final AppProperties appProperties;
     private final UserRefreshTokenRepository userRefreshTokenRepository;

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -46,7 +46,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
 
     /**
-     * @param request
      * @param response
      * @param authentication
      * @return 리다이렉트할 Url 반환, 액세스 토큰과 리프레시 토큰 생성하여 응답 헤더에 담기 수행.
@@ -77,10 +76,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             token.setRefreshToken(refreshToken.getToken());
         } else { // 기존에 리프레시 토큰을 한번도 발급받지 않은 유저, 즉 현재 처음으로 소셜로그인하는 경우, refresh token 신규 저장.
             UserRefreshToken newToken = UserRefreshToken.builder()
+                    .user(user)
                     .email(user.getEmail())
                     .refreshToken(refreshToken.getToken())
                     .build();
-            userRefreshTokenRepository.saveAndFlush(newToken);
+            userRefreshTokenRepository.save(newToken);
         }
 
         response.setStatus(HttpServletResponse.SC_OK); // 200

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/model/OAuthVendor.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/model/OAuthVendor.java
@@ -10,7 +10,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 
-@RequiredArgsConstructor
+
 public enum OAuthVendor {
 
 
@@ -67,6 +67,8 @@ public enum OAuthVendor {
             return ProviderType.KAKAO;
         }
     };
+
+
 
     /**
      * TODO 주석 달기

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/service/IssueRefreshService.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/service/IssueRefreshService.java
@@ -30,7 +30,7 @@ public class IssueRefreshService {
     private final AuthTokenProvider tokenProvider;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public void refreshToken(HttpServletRequest request, HttpServletResponse response){
         log.info("리프레시 토큰 발급 준비중...");

--- a/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/token/AuthToken.java
+++ b/server/timer-service/src/main/java/com/gdsc/timerservice/oauth/token/AuthToken.java
@@ -5,7 +5,6 @@ import com.gdsc.timerservice.oauth.entity.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Date;

--- a/server/timer-service/src/main/resources/application.yml
+++ b/server/timer-service/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 app:
   auth:
     tokenSecret: 926D96C90030DD58429D2751AC1BDBBC
-    tokenExpiry: 1800000 # 60000(1분) # 1800000 # 30분 1000(1초) * 60 * 30
-    refreshTokenExpiry: 604800000 # 리프레시토큰의 유효기간은 7일
+    tokenExpiry: 604800000 # 액세스 토큰의 유효기간은 7일
+    refreshTokenExpiry: 2419200000 # 리프레시 토큰의 유효기간은 한달
 
 

--- a/server/timer-service/src/main/resources/application.yml
+++ b/server/timer-service/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -36,7 +36,7 @@ spring:
 app:
   auth:
     tokenSecret: 926D96C90030DD58429D2751AC1BDBBC
-    tokenExpiry: 10 # 60000(1분) # 1800000 # 30분 1000(1초) * 60 * 30
+    tokenExpiry: 1800000 # 60000(1분) # 1800000 # 30분 1000(1초) * 60 * 30
     refreshTokenExpiry: 604800000 # 리프레시토큰의 유효기간은 7일
 
 


### PR DESCRIPTION
## UserSetting api
- **GET** `/api/user/users` 전체 User 조회
- **GET** `/api/user/setting` User 설정 조회
- **PATCH** `/api/user/setting` User 설정 수정

## 토큰 로직 정상 작동 (인가처리)
소셜 로그인을 성공적으로 완료하시면 아래와 같이 두 토큰값을 받습니다.
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/82166132/177500241-140df735-e192-489b-8f20-87aa73a8d367.png">
매 요청마다 요청헤더의 Authorization Bearer 를 키로 하는 곳에 발급받은 액세스 토큰을 담아 서버에 전송해주세요!
<img width="642" alt="image" src="https://user-images.githubusercontent.com/82166132/177500133-77fd6a22-e6d9-4afa-ad01-b37cbec5549b.png">

## 토큰 기간 수정
`access token` 의 만료기간은 **일주일**, `refresh token` 의 만료기간은 **한달**로 수정하였습니다.

## 현재 접속 유저 pk 찾아오는 법
@CurrentUser 라는 어노테이션을 만들었습니다. 이 어노테이션을 통해 현재 접속한 유저의 정보를 가지고 올 수 있습니다.
### controller/user/UserController.java
<img width="599" alt="image" src="https://user-images.githubusercontent.com/82166132/177501006-1913d184-c51d-4bdf-9438-9e8015d424f0.png">
ㅊㅊ